### PR TITLE
finger distance launch file fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,7 @@ src/hardware_interface/senseglove_hardware/SenseCom/Linux/sessionLog.txt
 src/cmake-build-debug/*
 src/CMakeLists.txt
 
+src/senseglove/senseglove_shared_resources/calibration/*
+
 .idea/*
 .catkin_tools/*

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,12 @@ src/hardware_interface/senseglove_hardware/SenseCom/Linux/sessionLog.txt
 src/cmake-build-debug/*
 src/CMakeLists.txt
 
+src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/__pycache__
+src/senseglove/senseglove_launch/scripts/sessionLog.txt
 src/senseglove/senseglove_shared_resources/calibration/*
+
+senseglove_ros_ws.code-workspace
 
 .idea/*
 .catkin_tools/*
+.vscode/

--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ As such, the user has to define which glove is connected to the system.
 5. source your workspace
 6. proceed as if you were dealing with 2 sensegloves
 
+### Remarks for using the finger distance node: ###
+The finger distance package is meant to publish the distance between the fingertips through a rosnode as a means to control robotic grippers. This package also provides a calibration class that provides a service server. The service is easily called from the rqt_service_caller plugin.Instructions for the calibration are printed on your terminal.
 ## 3. To do: ##
 This is a small to do list for the upcoming features in this repository these will be added as issues as well.
 * Custom Exceptions for easy debugging
-* Provide specialized script for using a single senseglove
 * Provide speed and acceleration data of the fingertippositions as well as for the encoder data.

--- a/src/hardware_interface/senseglove_hardware/include/senseglove_hardware/actuation_mode.h
+++ b/src/hardware_interface/senseglove_hardware/include/senseglove_hardware/actuation_mode.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Project March.
+// Copyright 2022 Senseglove.
 
 #ifndef SENSEGLOVE_HARDWARE_ACTUATION_MODE_H
 #define SENSEGLOVE_HARDWARE_ACTUATION_MODE_H

--- a/src/senseglove/senseglove_finger_distance/CMakeLists.txt
+++ b/src/senseglove/senseglove_finger_distance/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(catkin REQUIRED COMPONENTS
     actionlib
     actionlib_msgs
     genmsg
+    rospy
     senseglove_shared_resources
     std_msgs
     )

--- a/src/senseglove/senseglove_finger_distance/scripts/senseglove_finger_distance_node
+++ b/src/senseglove/senseglove_finger_distance/scripts/senseglove_finger_distance_node
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2.7
 import senseglove_finger_distance.finger_distance_node
 import sys
 

--- a/src/senseglove/senseglove_finger_distance/scripts/senseglove_haptics_node
+++ b/src/senseglove/senseglove_finger_distance/scripts/senseglove_haptics_node
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2.7
 import senseglove_finger_distance.haptics_node_action_interface
 
 if __name__ == '__main__':

--- a/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_calibration.py
+++ b/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_calibration.py
@@ -4,7 +4,7 @@ import rospy
 import rosparam
 import sys
 from os.path import isdir, exists
-#import rospkg
+import rospkg
 from senseglove_shared_resources.msg import FingerDistanceFloats
 
 

--- a/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_calibration.py
+++ b/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_calibration.py
@@ -192,7 +192,7 @@ class Calibration:
         # Set parameters
         rospy.set_param('~pinch_calibration_min', self.pinch_calibration_min)
         rospy.set_param('~pinch_calibration_max', self.pinch_calibration_max)
-        config_folder = rospkg.RosPack().get_path('senseglove_shared_resources') + "/calib"
+        config_folder = rospkg.RosPack().get_path('senseglove_shared_resources') + "/calibration"
 
         if not isdir(config_folder):
             rospy.logwarn("Could not locate calibration folder %s, not saving." % config_folder)

--- a/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_calibration.py
+++ b/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_calibration.py
@@ -4,7 +4,7 @@ import rospy
 import rosparam
 import sys
 from os.path import isdir, exists
-import rospkg
+#import rospkg
 from senseglove_shared_resources.msg import FingerDistanceFloats
 
 

--- a/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
+++ b/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
@@ -39,6 +39,27 @@ class FingerTipHandler:
         print(self.calib_srv.resolved_name)
         print("Done setting up calibration")
 
+    def calibrate_service(self, call):
+        # Stop publishing commands & feedback
+        print("Executing calibration service")
+        self.calibrating = True
+
+        old_calib = self.calibration
+        if call.name is None:
+            call.name = "Unnamed_" + str(rospy.get_time())
+        print("calibration from call.name: ", call.name)
+        glove_nr = 0 if self.ns == '/lh/' else 1
+        self.calibration = Calibration(name=call.name, glove_nr=glove_nr)
+        result = self.calibration.run_interactive_calibration()
+
+        if not result:
+            # Failed; Restore previous calibration
+            self.calibration = old_calib
+
+        # Resume publishing
+        self.calibrating = False
+        return result
+
     def apply_calib(self, pinch_value=0.0, pinch_combination=0, mode='nothing'):
         if mode == 'nothing':
             return pinch_value

--- a/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
+++ b/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
@@ -21,24 +21,23 @@ class FingerTipHandler:
         self._setup_calibration()
 
     def _setup_calibration(self):
-        print("Setting up calibration")
+        rospy.loginfo("Setting up calibration")
         # Calibration: setup default
         self.calibration = Calibration(name="default")
 
         # If calibration already on param server, load it
         if rospy.has_param('~pinch_calibration_min') and rospy.has_param('~pinch_calibration_max'):
-            print("Found calibration data on server")
+            rospy.loginfo("Found calibration data on server")
             self.calibration = Calibration("from_param_server")
             self.calibration.pinch_calibration_min = rospy.get_param('~pinch_calibration_min')
             self.calibration.pinch_calibration_max = rospy.get_param('~pinch_calibration_max')
         else:
-            print("No calibration data found, using defaults")
+            rospy.logwarn("No calibration data found, using defaults")
 
         # Declare calibration service
         self.calib_srv = rospy.Service("~Calibrate", Calibrate, self.calibrate_service)
         self.calibrating = False
-        print(self.calib_srv.resolved_name)
-        print("Done setting up calibration")
+        rospy.loginfo("Done setting up calibration for %s", self.calib_srv.resolved_name)
 
     def calibrate_service(self, call):
         # Stop publishing commands & feedback
@@ -48,7 +47,7 @@ class FingerTipHandler:
         old_calib = self.calibration
         if call.name is None:
             call.name = "Unnamed_" + str(rospy.get_time())
-        print("calibration from call.name: ", call.name)
+        rospy.loginfo("calibration from call.name: %s", call.name)
         self.calibration = Calibration(name=call.name, glove_nr=self.glove_nr)
         result = self.calibration.run_interactive_calibration()
 
@@ -92,7 +91,7 @@ class FingerTipHandler:
                 self.calibration.pinch_calibration_min = rospy.get_param('~pinch_calibration_min')
                 self.calibration.pinch_calibration_max = rospy.get_param('~pinch_calibration_max')
             else:
-                rospy.logwarn_throttle(60, "No calibration data found, using defaults")
+                rospy.logwarn_throttle(60, "No calibration data found when publishing fingerdistances, using defaults")
 
         for i in range(len(self.finger_nrs)):
             self.finger_tips[i].x = data.finger_tip_positions[i].x

--- a/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
+++ b/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
@@ -12,6 +12,7 @@ class FingerTipHandler:
         self.finger_nrs = finger_nrs
         self.calib_mode = calib_mode
         self.finger_tips = [FingerTipVector() for i in self.finger_nrs]
+        self.glove_nr = glove_nr
         self.senseglove_ns = "/senseglove/" + str(int(glove_nr) / 2) + str(self.handedness_list[int(glove_nr) % 2])
         rospy.Subscriber(self.senseglove_ns + "/senseglove_states", SenseGloveState,
                          callback=self.callback, queue_size=1)  # queue size is necessary otherwise it is infinite
@@ -48,8 +49,7 @@ class FingerTipHandler:
         if call.name is None:
             call.name = "Unnamed_" + str(rospy.get_time())
         print("calibration from call.name: ", call.name)
-        glove_nr = 0 if self.ns == '/lh/' else 1
-        self.calibration = Calibration(name=call.name, glove_nr=glove_nr)
+        self.calibration = Calibration(name=call.name, glove_nr=self.glove_nr)
         result = self.calibration.run_interactive_calibration()
 
         if not result:

--- a/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
+++ b/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
@@ -86,7 +86,7 @@ class FingerTipHandler:
         if not self.calibration.is_calibrated():
             # If calibration on param server, load it
             if rospy.has_param('~pinch_calibration_min') and rospy.has_param('~pinch_calibration_max'):
-                rospy.loginfo("Found calibration data on server")
+                rospy.logdebug_throttle(60, "Found calibration data on server")
                 self.calibration = Calibration("from_param_server")
                 self.calibration.pinch_calibration_min = rospy.get_param('~pinch_calibration_min')
                 self.calibration.pinch_calibration_max = rospy.get_param('~pinch_calibration_max')

--- a/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
+++ b/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
@@ -54,6 +54,7 @@ class FingerTipHandler:
 
         if not result:
             # Failed; Restore previous calibration
+            
             self.calibration = old_calib
 
         # Resume publishing
@@ -91,7 +92,7 @@ class FingerTipHandler:
                 self.calibration.pinch_calibration_min = rospy.get_param('~pinch_calibration_min')
                 self.calibration.pinch_calibration_max = rospy.get_param('~pinch_calibration_max')
             else:
-                rospy.logwarn_throttle(30, "No calibration data found, using defaults")
+                rospy.logwarn_throttle(60, "No calibration data found, using defaults")
 
         for i in range(len(self.finger_nrs)):
             self.finger_tips[i].x = data.finger_tip_positions[i].x

--- a/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
+++ b/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
@@ -54,7 +54,7 @@ class FingerTipHandler:
 
         if not result:
             # Failed; Restore previous calibration
-            
+            rospy.logwarn("Calibration was unsuccesful: using old calibration")
             self.calibration = old_calib
 
         # Resume publishing

--- a/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
+++ b/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
@@ -1,5 +1,6 @@
 import rospy
 from senseglove_shared_resources.msg import SenseGloveState, FingerDistanceFloats
+from senseglove_shared_resources.srv import Calibrate
 from finger_distance_calibration import Calibration
 from math import sqrt, pow
 
@@ -16,7 +17,27 @@ class FingerTipHandler:
                          callback=self.callback, queue_size=1)  # queue size is necessary otherwise it is infinite
         self.pub = rospy.Publisher(self.senseglove_ns + "/finger_distances", FingerDistanceFloats, queue_size=1)
 
-        self.calibration = Calibration("default")
+        self._setup_calibration()
+
+    def _setup_calibration(self):
+        print("Setting up calibration")
+        # Calibration: setup default
+        self.calibration = Calibration(name="default")
+
+        # If calibration already on param server, load it
+        if rospy.has_param('~pinch_calibration_min') and rospy.has_param('~pinch_calibration_max'):
+            print("Found calibration data on server")
+            self.calibration = Calibration("from_param_server")
+            self.calibration.pinch_calibration_min = rospy.get_param('~pinch_calibration_min')
+            self.calibration.pinch_calibration_max = rospy.get_param('~pinch_calibration_max')
+        else:
+            print("No calibration data found, using defaults")
+
+        # Declare calibration service
+        self.calib_srv = rospy.Service("~Calibrate", Calibrate, self.calibrate_service)
+        self.calibrating = False
+        print(self.calib_srv.resolved_name)
+        print("Done setting up calibration")
 
     def apply_calib(self, pinch_value=0.0, pinch_combination=0, mode='nothing'):
         if mode == 'nothing':

--- a/src/senseglove/senseglove_launch/launch/senseglove_demo.launch
+++ b/src/senseglove/senseglove_launch/launch/senseglove_demo.launch
@@ -1,4 +1,5 @@
 <launch>
+    <arg name="use_rviz" default="true"/>
     <arg name="use_left" default="true"/>
     <arg name="use_right" default="true"/>
     <arg name="use_both" value="$(eval arg('use_left') and arg('use_right'))"/>
@@ -9,5 +10,5 @@
     <arg name="rvizconfig" value="$(find senseglove_description)/urdf_both.rviz" if="$(eval use_both)"/>
 
     <node pkg="senseglove_launch" type="startGlove.sh" name="startGlove" args="$(find senseglove_hardware) $(arg use_left) $(arg use_right)" output="screen" respawn="false" />
-    <node name="rviz" pkg="rviz" type="rviz" args="-d $(arg rvizconfig)" required="true" />
+    <node name="rviz" pkg="rviz" type="rviz" args="-d $(arg rvizconfig)" required="true" if="$(eval use_rviz)"/>
 </launch>

--- a/src/senseglove/senseglove_launch/launch/senseglove_finger_distance_demo.launch
+++ b/src/senseglove/senseglove_launch/launch/senseglove_finger_distance_demo.launch
@@ -14,10 +14,10 @@
     <node pkg="senseglove_launch" type="startGlove.sh" name="startGlove" args="$(find senseglove_hardware) $(arg use_left) $(arg use_right)" output="screen" respawn="false" />
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(arg rvizconfig)" required="true" if="$(eval use_rviz)"/>
 
-    <node name="senseglove_finger_distance_left" pkg="senseglove_finger_distance" type="senseglove_finger_distance_node" args="0 $(arg calibration_mode)">
+    <node name="senseglove_finger_distance_left" pkg="senseglove_finger_distance" type="senseglove_finger_distance_node" args="0 $(arg calibration_mode)" output="screen" >
 	    <remap from="/senseglove/0/lh/finger_distances" to="/lh/senseglove/finger_distances"/>
     </node>
-    <node name="senseglove_finger_distance_right" pkg="senseglove_finger_distance" type="senseglove_finger_distance_node" args="1 $(arg calibration_mode)">
+    <node name="senseglove_finger_distance_right" pkg="senseglove_finger_distance" type="senseglove_finger_distance_node" args="1 $(arg calibration_mode)" output="screen" >
 	    <remap from="/senseglove/0/rh/finger_distances" to="/rh/senseglove/finger_distances"/>
     </node>
 </launch>

--- a/src/senseglove/senseglove_launch/launch/senseglove_finger_distance_demo.launch
+++ b/src/senseglove/senseglove_launch/launch/senseglove_finger_distance_demo.launch
@@ -1,5 +1,7 @@
 <launch>
     <arg name="calibration_mode" default="nothing" doc="Choose the calibration mode of the senseglove; nothing, minimum, normalized"/>
+    <arg name="calibration_file_left" default="None" doc="Name of the calibration file without.yaml, if it is equal to None no file will be loaded."/>
+    <arg name="calibration_file_right" default="None" doc="Name of the calibration file without.yaml, if it is equal to None no file will be loaded."/>
 
     <arg name="use_rviz" default="true"/>
     <arg name="use_left" default="true"/>
@@ -16,8 +18,10 @@
 
     <node name="senseglove_finger_distance_left" pkg="senseglove_finger_distance" type="senseglove_finger_distance_node" args="0 $(arg calibration_mode)" output="screen" >
 	    <remap from="/senseglove/0/lh/finger_distances" to="/lh/senseglove/finger_distances"/>
+        <rosparam command="load" file="$(find senseglove_shared_resources)/calibration/$(arg calibration_file_left).yaml" unless="$(eval calibration_file_left=='None')"/>
     </node>
     <node name="senseglove_finger_distance_right" pkg="senseglove_finger_distance" type="senseglove_finger_distance_node" args="1 $(arg calibration_mode)" output="screen" >
 	    <remap from="/senseglove/0/rh/finger_distances" to="/rh/senseglove/finger_distances"/>
+        <rosparam command="load" file="$(find senseglove_shared_resources)/calibration/$(arg calibration_file_right).yaml" unless="$(eval calibration_file_right=='None')"/>
     </node>
 </launch>

--- a/src/senseglove/senseglove_launch/launch/senseglove_finger_distance_demo.launch
+++ b/src/senseglove/senseglove_launch/launch/senseglove_finger_distance_demo.launch
@@ -1,7 +1,18 @@
 <launch>
     <arg name="calibration_mode" default="nothing" doc="Choose the calibration mode of the senseglove; nothing, minimum, normalized"/>
 
-    <node pkg="senseglove_launch" type="startGlove.sh" name="startGlove" args="$(find senseglove_hardware)" output="screen" respawn="false" />
+    <arg name="use_rviz" default="true"/>
+    <arg name="use_left" default="true"/>
+    <arg name="use_right" default="true"/>
+    <arg name="use_both" value="$(eval arg('use_left') and arg('use_right'))"/>
+
+    <!--Passing through here ensures the use of the correct urdf_x.rviz file by overwriting if necessary-->
+    <arg name="rvizconfig" value="$(find senseglove_description)/urdf_left.rviz" if="$(eval use_both==false and use_left==true)"/>
+    <arg name="rvizconfig" value="$(find senseglove_description)/urdf_right.rviz" if="$(eval use_both==false and use_right==true)"/>
+    <arg name="rvizconfig" value="$(find senseglove_description)/urdf_both.rviz" if="$(eval use_both)"/>
+
+    <node pkg="senseglove_launch" type="startGlove.sh" name="startGlove" args="$(find senseglove_hardware) $(arg use_left) $(arg use_right)" output="screen" respawn="false" />
+    <node name="rviz" pkg="rviz" type="rviz" args="-d $(arg rvizconfig)" required="true" if="$(eval use_rviz)"/>
 
     <node name="senseglove_finger_distance_left" pkg="senseglove_finger_distance" type="senseglove_finger_distance_node" args="0 $(arg calibration_mode)">
 	    <remap from="/senseglove/0/lh/finger_distances" to="/lh/senseglove/finger_distances"/>

--- a/src/senseglove/senseglove_shared_resources/CMakeLists.txt
+++ b/src/senseglove/senseglove_shared_resources/CMakeLists.txt
@@ -17,6 +17,11 @@ add_message_files(
     SenseGloveState.msg
 )
 
+add_service_files(
+  FILES
+  Calibrate.srv
+)
+
 #add_action_files(
 #    DIRECTORY action
 #    FILES

--- a/src/senseglove/senseglove_shared_resources/srv/Calibrate.srv
+++ b/src/senseglove/senseglove_shared_resources/srv/Calibrate.srv
@@ -1,0 +1,5 @@
+# A service to request calibration
+
+string name  # Optional: name for this calibration profile
+---
+bool success


### PR DESCRIPTION
This small PR updates dependency on python 2.7 instead of 3 and explicitly adds rospy as a dependency in the cmakelists.txt. It also adjusts the finger_distance demo launch file to act more like the normal demo file. Finally an argument has been implemented that allows the user to chose whether or not RVIZ gets started as well.