### PR TITLE
Feature/finger distance calibration service

### DIFF
--- a/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
+++ b/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
@@ -33,12 +33,10 @@ class FingerTipHandler:
             print("No calibration data found, using defaults")
 
         # Declare calibration service
-        self.calib_srv = rospy.Service("shadow_ros_control/calibrate", Calibrate, self.calibrate_service)  # ~
-        # self.calib_srv = rospy.Service(self.ns + "/shadow_ros_control/Calibrate", Calibrate, self.calibrate_service)
+        self.calib_srv = rospy.Service("~Calibrate", Calibrate, self.calibrate_service)
         self.calibrating = False
         print(self.calib_srv.resolved_name)
         print("Done setting up calibration")
-
 
     def apply_calib(self, pinch_value=0.0, pinch_combination=0, mode='nothing'):
         if mode == 'nothing':

--- a/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
+++ b/src/senseglove/senseglove_finger_distance/src/senseglove_finger_distance/finger_distance_node.py
@@ -1,5 +1,6 @@
 import rospy
 from senseglove_shared_resources.msg import SenseGloveState, FingerDistanceFloats
+from senseglove_shared_resources.srv import Calibrate
 from finger_distance_calibration import Calibration
 from math import sqrt, pow
 

--- a/src/senseglove/senseglove_shared_resources/CMakeLists.txt
+++ b/src/senseglove/senseglove_shared_resources/CMakeLists.txt
@@ -17,6 +17,11 @@ add_message_files(
     SenseGloveState.msg
 )
 
+add_service_files(
+  FILES
+  Calibrate.srv
+)
+
 #add_action_files(
 #    DIRECTORY action
 #    FILES

--- a/src/senseglove/senseglove_shared_resources/srv/Calibrate.srv
+++ b/src/senseglove/senseglove_shared_resources/srv/Calibrate.srv
@@ -1,0 +1,5 @@
+# A service to request calibration
+
+string name  # Optional: name for this calibration profile
+---
+bool success


### PR DESCRIPTION
Add a calibration service server to the finger distance controller. This calibration sequence asks the user to perform pinching movements from which we can determine whether or not the fingers are closed. using this information we can publish the distance between the fingertips and use this information to control robotic grippers.