### PR TITLE
Fix unterminated quoted string in Dockerfile

### DIFF
--- a/docker/Dockerfile.ros2
+++ b/docker/Dockerfile.ros2
@@ -24,7 +24,7 @@ WORKDIR ${ROS_WORKSPACE}
 RUN rosdep init || true && rosdep update
 
 RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /root/.bashrc
-RUN echo "source "${ROS_WORKSPACE}/install/setup.bash" >> /root/.bashrc
+RUN echo "source ${ROS_WORKSPACE}/install/setup.bash" >> /root/.bashrc
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
When building the image from `Dockerfile`, the following error occurs:

/bin/sh: 1: Syntax error: Unterminated quoted string